### PR TITLE
Update DICOM-rs to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,15 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+name = "visualize_oct_dicom"
+path = "src/lib.rs"
+
+[[bin]]
+name = "pdf_generator"
+path = "src/main.rs"
+doc = false
+
 [dependencies]
 
 dicom = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,7 @@ edition = "2018"
 
 [dependencies]
 
-dicom-object = { git = "https://github.com/cozyDoomer/dicom-rs", branch = "feature/parse-invalid-datetime"}
-dicom-core = { git = "https://github.com/cozyDoomer/dicom-rs", branch = "feature/parse-invalid-datetime"}
-dicom-dictionary-std = { git = "https://github.com/cozyDoomer/dicom-rs", branch = "feature/parse-invalid-datetime"}
-dicom-encoding = { git = "https://github.com/cozyDoomer/dicom-rs", branch = "feature/parse-invalid-datetime"}
+dicom = "0.3"
 
 printpdf = { git = "https://github.com/fschutt/printpdf.git" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@
 // 6.346898043 6.312235771 6.742419365 cirrus
 // 1.744876646 1.981386831 1.933800719 spectralis
 
-mod utils;
-mod loader;
+pub mod utils;
+pub mod loader;
 
 #[cfg(test)]
 mod test_utils {
@@ -31,9 +31,9 @@ mod test_utils {
 
     #[test]
     fn test_calculate_image_positions() {
-        assert_eq!((Point{x: 408.0, y: 272.0}, Point{x: 1000.0, y: 272.0}), utils::calculate_image_positions([512, 496]));
-        assert_eq!((Point{x: 408.0, y:   8.0}, Point{x: 1000.0, y:   8.0}), utils::calculate_image_positions([512, 1024]));
-        assert_eq!((Point{x: 720.0, y:   8.0}, Point{x: 1000.0, y:   8.0}), utils::calculate_image_positions([200, 1024]));
+        assert_eq!((Point{x: 408.0, y: 272.0}, Point{x: 1000.0, y: 272.0}), utils::calculate_image_positions(&[512, 496]));
+        assert_eq!((Point{x: 408.0, y:   8.0}, Point{x: 1000.0, y:   8.0}), utils::calculate_image_positions(&[512, 1024]));
+        assert_eq!((Point{x: 720.0, y:   8.0}, Point{x: 1000.0, y:   8.0}), utils::calculate_image_positions(&[200, 1024]));
     }
 
     //#[bench]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,15 +2,14 @@
 generates pdfs from subfolders of oct volumes and corresponding probability mask
 */
 
-mod loader;
-mod utils;
+use visualize_oct_dicom::loader;
+use visualize_oct_dicom::utils;
 
 use std::fs::File;
 use quicli::prelude::*;
 use structopt::StructOpt;
 use scan_dir::ScanDir;
 use std::io::BufWriter;
-use std::convert::TryInto;
 use std::time::Instant;
 use std::path::{PathBuf};
 


### PR DESCRIPTION
Thank you for your interest in using DICOM-rs!

This pull request updates DICOM-rs to its latest version, 0.3. I also took the liberty of applying a few fixes and refactoring the project a bit. Please let me know if this works for you, or if you would like to split the two contributions.

- The new parser behavior is to preserve textual values, so it no longer fails to read data sets with invalid date/time values.
- The library's new value access methods make it easier to retrieve values from DICOM elements. The helper `dicom_element_*` methods were removed, as they are no longer necessary.
- Refactored `loader` to fetch DICOM number attributes with the desired type directly.

- Explicitly declared `visualize_oct_dicom` as a library and `pdf_generator` as a binary: this makes separation of concerns and makes it so that the modules `loader` and `util` are not compiled twice.
- In main.rs, use the library `visualize_oct_dicom` instead of directly using the modules.
- Made modules in library public, so that they are accessible from the binary crate.
- Fixed test `test_calculate_image_positions` (missing array coercion into slice).